### PR TITLE
Fix duplicate account ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fix issue with duplicate account IDs in aggregator
+- SSE on S3 bucket
+
 ## [0.1.0] 2019-09-15
 - Initial release @alex.harvey

--- a/aggregator.tf
+++ b/aggregator.tf
@@ -8,7 +8,7 @@ resource "aws_config_configuration_aggregator" "configuration_aggregator" {
   count = var.is_aggregator ? 1 : 0
   name  = "aggregator"
   account_aggregation_source {
-    account_ids = concat([var.aggregator_account_id], var.source_account_ids)
+    account_ids = distinct(concat([var.aggregator_account_id], var.source_account_ids))
     all_regions = true
   }
 }

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,8 +1,16 @@
 resource "aws_s3_bucket" "bucket" {
-  count  = var.is_aggregator ? 1 : 0
+  count = var.is_aggregator ? 1 : 0
 
   acl    = "private"
   bucket = var.bucket_name
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   lifecycle_rule {
     id      = "log"
@@ -39,7 +47,7 @@ data "aws_iam_policy_document" "config" {
   }
 
   statement {
-    actions   = ["s3:PutObject"]
+    actions = ["s3:PutObject"]
     principals {
       type        = "Service"
       identifiers = ["config.amazonaws.com"]


### PR DESCRIPTION
When using the `aws_organizations_organization` it will grab the audit
account ID, creating duplicate IDs in the list passed to `account_ids`
(which fails the API call).