### PR TITLE
Support for newer provider and terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The below outlines the current parameters and defaults.
 |bucket_sse_algorithm|The server-side encryption algorithm to use|string|AES256|No|
 |bucket_kms_master_key|The AWS KMS master key ID used for the SSE-KMS encryption|string|null|No|
 |config_rules|A list of config rules. By not specifying, a minimum set of recommended rules are applied|map(any)|(map)|No|
+|include_global_resource_types|Specifies config includes al suported tpes of global resources|bool|true|No|
+| resource_types | List if resources to record | list(string) | null | No |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ AWS Config catpures point in time snapshots of the environment to allow for poin
 
 NOTE: Currently only supports AWS owned / managed rules - http://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html
 
-Terraform >= 0.12.6 is required for this module.
+Terraform >= 0.13.0 is required for this module.
+Provider hashicorp/aws >= 0.4.1 is required for this module
 
 ## Terraform AWS Config - Overview Diagram
 
@@ -54,6 +55,8 @@ The below outlines the current parameters and defaults.
 |aggregator_account_region|The AWS Region of the aggregator account|string|null|No|
 |source_account_ids|List of 12-digit account IDs of the accounts being aggregated|list(string)|[]|No|
 |bucket_name|The bucket name - required by both aggregator and source accounts|string|""|Yes|
+|bucket_sse_algorithm|The server-side encryption algorithm to use|string|AES256|No|
+|bucket_kms_master_key|The AWS KMS master key ID used for the SSE-KMS encryption|string|null|No|
 |config_rules|A list of config rules. By not specifying, a minimum set of recommended rules are applied|map(any)|(map)|No|
 
 ### Outputs

--- a/recorder.tf
+++ b/recorder.tf
@@ -17,7 +17,7 @@ resource "aws_config_delivery_channel" "config" {
     delivery_frequency = var.delivery_frequency
   }
   sns_topic_arn = aws_sns_topic.config.arn
-  depends_on     = [aws_config_configuration_recorder.config]
+  depends_on    = [aws_config_configuration_recorder.config]
 }
 
 resource "aws_config_configuration_recorder_status" "config" {

--- a/recorder.tf
+++ b/recorder.tf
@@ -5,7 +5,9 @@ locals {
 resource "aws_config_configuration_recorder" "config" {
   name = local.config_name
   recording_group {
-    include_global_resource_types = true
+    all_supported                 = var.resource_types != null ? false : true
+    include_global_resource_types = var.resource_types != null ? false : var.include_global_resource_types
+    resource_types                = var.resource_types
   }
   role_arn = aws_iam_role.config_role.arn
 }

--- a/role.tf
+++ b/role.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     actions = ["sts:AssumeRole"]
     principals {
       identifiers = ["config.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
   }
 }

--- a/rules.tf
+++ b/rules.tf
@@ -8,5 +8,5 @@ resource "aws_config_config_rule" "config_rules" {
   scope {
     compliance_resource_types = each.value.scope.compliance_resource_types
   }
-  depends_on = ["aws_config_configuration_recorder.config"]
+  depends_on = [aws_config_configuration_recorder.config]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,10 +51,22 @@ variable "bucket_name" {
   description = "The bucket name - required by both aggregator and source accounts"
 }
 
+variable "bucket_sse_algorithm" {
+  type        = string
+  description = "The server-side encryption algorithm to use"
+  default     = "AES256"
+}
+
+variable "bucket_kms_master_key" {
+  type        = string
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption"
+  default     = null
+}
+
 variable "config_rules" {
   type        = map(any)
   description = "A list of config rules. By not specifying, a minimum set of recommended rules are applied"
-  default     = {
+  default = {
     eip_attached = {
       name = "eip-attached"
       source = {

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,15 @@ variable "config_rules" {
     }
   }
 }
+
+variable "include_global_resource_types" {
+  type        = bool
+  description = "Specifies whether AWS Config includes all supported types of global resources with the resources that it records"
+  default     = true
+}
+
+variable "resource_types" {
+  description = "A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail)"
+  type        = list(string)
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.1"
+    }
+  }
 }


### PR DESCRIPTION
update readme
Removed deprecated quotes
Support provider hashicorp/aws >= 4.1
Support terraform >= 0.13.0
Adds optional support for bucket encryption using KMS keys